### PR TITLE
Fixed the reward sending function

### DIFF
--- a/src/resources/FederatedLearning.sol
+++ b/src/resources/FederatedLearning.sol
@@ -80,6 +80,7 @@ contract FederatedLearning {
         require(_trainingValue > 0, "Training value must be greater than 0");
 
         uint256 reward = calculateReward(_modelId, _trainingValue);
+        
         require(
             reward <= model.rewardPool,
             "Insufficient reward pool for this training"
@@ -92,9 +93,10 @@ contract FederatedLearning {
         trainer.trainedModels.push(_modelId);
 
         emit ModelTrained(_modelId, msg.sender, reward);
-
+        // Convert the reward value to Wei as call.value function expects arguments in WEI not ETHER
+        uint256 rewardInWei = (reward)*((10)**(18)); // 1 Eth = 10^18 Wei
         // Transfer the reward to the trainer using call instead of transfer
-        (bool success, ) = msg.sender.call.value(reward)("");
+        (bool success, ) = msg.sender.call.value(rewardInWei)("");
         require(success, "Transfer failed.");
     }
 


### PR DESCRIPTION
- **Issue:**
  - The reward calculation logic was computed as follows:
`reward = trainingValue * rewardPool / 1000`
With a training value of 10 , and  reward pool as 1 ETH the result was 0.01 ETH. Since decimal values are not permitted for this function, it failed during execution.

- **Solution:**
  - The calculation has been adjusted to convert the ETH value to Wei. Specifically, the conversion factor of 10^18 (representing the Wei equivalent of 1 ETH) has been applied to ensure the correct denomination is used during the function call.

- **Testing:**
  - The changes were tested in a local Ganache environment using the Remix IDE to verify that the conversion correctly resolves the issue.